### PR TITLE
Fix issue with number of returned documents in RetrieverWithScore

### DIFF
--- a/src/rag/chain.py
+++ b/src/rag/chain.py
@@ -107,7 +107,7 @@ class RetrieverWithScore(VectorStoreRetriever):
     ) -> List[Document]:
         """Get docs, adding score information."""
         docs, scores = zip(
-            *self.vectorstore.similarity_search_with_score(query, **search_kwargs)
+            *self.vectorstore.similarity_search_with_score(query, **self.search_kwargs)
         )
         for doc, score in zip(docs, scores):
             doc.metadata["score"] = score

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -200,7 +200,6 @@ def filter_sources(docs):
     # sort docs by score
     #docs = sorted(docs, key=lambda x: x.metadata["score"], reverse=True)
     
-    
     # Split by the maximum distance between scores
     # XXX: Could use something more sophisticated such as Otsu thresholding...
     max_diff = 0
@@ -208,18 +207,15 @@ def filter_sources(docs):
     for i in range(len(docs)-1):        
         diff = docs[i+1].metadata["score"] - docs[i].metadata["score"]
 
-        print(diff)
-
         if (diff > max_diff):
             max_diff = diff
             max_diff_index = i
 
-    print(max_diff, max_diff_index)
-
     top_docs = docs[0:max_diff_index+1]
 
-    #return top_docs
-    return docs
+    print(f"Kept {len(top_docs)} of {len(docs)}")
+
+    return top_docs
 
 
 def parse_text(answer, context) -> str:
@@ -275,13 +271,9 @@ def parse_text(answer, context) -> str:
 def draw_sources(sources, showSources):
     if len(sources) == 0: 
         return    
-    
-    print("NUM:", len(sources))
 
     with st.expander(f"Source{'s' if len(sources) > 1 else ''}", expanded=showSources):
         output = ""
-
-        print(len(sources))
         
         for i, source in enumerate(sources):                    
             # Add the link


### PR DESCRIPTION
Just needed to use the `search_kwargs` member variable instead of the one passed in to` _get_docs_with_query`, which was empty.